### PR TITLE
Fix requirements filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Using radarr_add_from_list/sonarr_add_from_list
 The input list file has to have the format. 
 It has to have MovieName/ShowName,Year,imdbid   **imdbid is Optional Makes it easer to find movie/TV show
 
-Use pip install -r requirments.txt to install the required python modules 
+Use pip install -r requirements.txt to install the required python modules 
 
 Movies CSV
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# pip install -r requirements.txt
+requests
+colorlog

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,3 +1,0 @@
-# pip install -r requirments.txt
-requests
-colorlog


### PR DESCRIPTION
## Summary
- rename `requirments.txt` to `requirements.txt`
- fix README to refer to `requirements.txt`
- update comment in new requirements file

## Testing
- `python -m py_compile $(ls *.py)` *(fails: SyntaxError in export_trakt.py)*

------
https://chatgpt.com/codex/tasks/task_e_685c68bbb4308326a164d9f32c29c51b