### PR TITLE
Add MusicBrainz fallback lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Backstreet Boys,2f569e60-0a1b-4fb9-95a4-3dc1525d1aad
 
 ```
 
+If `foreignArtistId` is omitted, `lidarr_add_from_list.py` will attempt to
+retrieve the MusicBrainz ID automatically.
+
 Run the GUI with
 ```
 $ python3 arr_gui.py


### PR DESCRIPTION
## Summary
- fallback to MusicBrainz API when no `foreignArtistId` is provided
- document automatic lookup in README

## Testing
- `python3 -m py_compile lidarr_add_from_list.py`

------
https://chatgpt.com/codex/tasks/task_e_6863a8fe38e88326965d0e8320ce54ac